### PR TITLE
Allow the server to be started with no certificate for testing

### DIFF
--- a/src/RpcRegistry.ts
+++ b/src/RpcRegistry.ts
@@ -79,12 +79,16 @@ export class RpcRegistry {
   }
 
   private static _addTls() {
-    let ca = FS.readFileSync(this.ca);
-    let cert = FS.readFileSync(this.cert);
-    let key = FS.readFileSync(this.key);
-    this._credentials = GRPC.ServerCredentials.createSsl(ca, [{
-      cert_chain: cert,
-      private_key: key
-    }], true);
+    if (!this.ca || !this.cert || !this.key) {
+        this._credentials = GRPC.ServerCredentials.createInsecure()
+    } else {
+        let ca = FS.readFileSync(this.ca);
+        let cert = FS.readFileSync(this.cert);
+        let key = FS.readFileSync(this.key);
+        this._credentials = GRPC.ServerCredentials.createSsl(ca, [{
+        cert_chain: cert,
+        private_key: key
+        }], true);
+    }
   }
 }


### PR DESCRIPTION
The `ca`, `cert`, and `key` properties are optional in the configuration, but at the moment they are required by the `start()` method. If they are not provided, `_addTls()` throws a `File Not Found` exception.

This patch starts the server in insecure mode if no values are provided for these config parameters.