### PR TITLE
Remove deprecation notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "xuezi",
   "license": "ISC",
   "dependencies": {
+    "@grpc/proto-loader": "^0.3.0",
     "grpc": "^1.12.4",
     "reflect-metadata": "^0.1.12",
     "ts-loader": "^4.4.2",

--- a/src/ServiceContainer.ts
+++ b/src/ServiceContainer.ts
@@ -6,6 +6,7 @@
  * @desc [description]
 */
 import * as GRPC from 'grpc';
+import * as protoLoader from '@grpc/proto-loader';
 
 export class ServiceContainer {
   static services: { service: any, target: Function }[] = [];
@@ -19,7 +20,14 @@ export class ServiceContainer {
    * @memberof ServiceContainer
    */
   static registryService(target: Function, path: string) {
-    let protoDescriptor = GRPC.load(path);
+    let packageDefinition = protoLoader.loadSync(path, {
+        keepCase: true,
+        longs: String,
+        enums: String,
+        defaults: true,
+        oneofs: true
+    });
+    let protoDescriptor = GRPC.loadPackageDefinition(packageDefinition);
 
     const packages = Object.keys(protoDescriptor);
     for (let packageKey of packages) {

--- a/src/decorator/Route.ts
+++ b/src/decorator/Route.ts
@@ -1,6 +1,6 @@
 import { ServiceContainer } from '../ServiceContainer';
 
-export function Route(target: Function, key: string, { value: route }: { value: Function }) {
+export function Route(target: any, key: string, { value: route }: { value?: any }) {
   if (!(route instanceof Function)) {
     throw new Error('Route decorator target must be a Function');
   }


### PR DESCRIPTION
This patch fixes #4.

BREAKING CHANGE:

Before, methods annotated with `@Route` needed to be lowercase. With this patch, those methods need to match the case of the proto definition.

[Updated: I thought this was because of the `keepcase` setting, but it looks like it is not]